### PR TITLE
Removes the forceConvert Parameter from RENDERUSER.

### DIFF
--- a/data/System/VarRENDERUSER.txt
+++ b/data/System/VarRENDERUSER.txt
@@ -3,10 +3,9 @@
 #VarRENDERUSER
 ---+++ RENDERUSER -- format information from the user mapping
    * The =%<nop>RENDERUSER{}%= variable is handled by the QueryUserPlugin
-   * Syntax: =%<nop>RENDERUSER{"<user ID>" type="..." format="..." userformat="..." groupformat="..." usericon="0|1"}%=
-   * The user ID should be a cUID, but conversion from login name or !WikiName can be enabled (see below).
-   * When the user ID is not defined (no _default_ parameter) the current user will be used. If it is empty (=%<nop>RENDERUSER{""}%=), all placeholders will be replaced by an empty string.
-   * Parameter =convert="on|off"= - can be enabled to convert the input to a cUID if it is not.
+   * Syntax: =%<nop>RENDERUSER{"USERID" type="..." format="..." userformat="..." groupformat="..." usericon="0|1"}%=
+   * The user USERID can be a cUID, wikiname or loginname
+   * When the user USERID is not defined (no _default_ parameter) the current user will be used. If it is empty (=%<nop>RENDERUSER{""}%=), all placeholders will be replaced by an empty string.
    * Parameter =type="..."= - can be set to =user=, =group= or =any= to specify which object to render. Defaults to =user=.
    * Parameter =format="..."= - format for each result. The following placeholders can be used: =$loginName=, =$wikiName=, =$displayName=, =$cUID=, =$email=. Each placeholder can also be written like =$json:loginName= to enable escaping for use within strings in JSON notation. Additionally, a placeholder of the form =$pref(ABC)= or =$pref(ABC,default value)= will expand to the value of the =ABC= preference. Placeholders added from a preference will be expanded, too.
    * Parameter =userformat= / =groupformat= - separate formats for use when both users and groups are returned; if not given, the normal =format= parameter is used.

--- a/lib/Foswiki/Plugins/QueryUserPlugin.pm
+++ b/lib/Foswiki/Plugins/QueryUserPlugin.pm
@@ -218,10 +218,7 @@ sub _RENDERUSER {
             displayName => '',
         };
     } elsif ($type eq 'user') {
-        my $convert = $params->{convert};
-        if (defined $params->{_DEFAULT} && (Foswiki::Func::isTrue($convert, 0) || $Foswiki::cfg{Plugins}{QueryUserPlugin}{ForceConvert})) {
-            $cUID = Foswiki::Func::getCanonicalUserID($cUID);
-        }
+        $cUID = Foswiki::Func::getCanonicalUserID($cUID);
         $info = _userinfo($session, $cUID);
     } else {
         if(_isUnifiedLogin()) {

--- a/lib/Foswiki/Plugins/QueryUserPlugin/Config.spec
+++ b/lib/Foswiki/Plugins/QueryUserPlugin/Config.spec
@@ -1,7 +1,2 @@
 # ---+ Extensions
 # ---++ QueryUserPlugin
-
-# **BOOLEAN**
-# Always force converting the default parameter to cUID.
-$Foswiki::cfg{Plugins}{QueryUserPlugin}{ForceConvert} = 0;
-


### PR DESCRIPTION
Forced conversion is now always enabled. Previously a macro call with a non cuid (e.g. wikiname) and disabled conversion lead to a corrupt user cache in the foswiki core. This had the side effect that acl checks for users failed although they had correct access rights, e.g. users could not pdf-print restricted minutes.